### PR TITLE
Added the function to activate or deactivate offerings to the provider class

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ provider.register(offering)
   });
 ```
 
-The offering registration is timeboxed and will expire by default in ten minutes, so for persistent offerings you should keep re-registering the offering in a timer loop.
+The offering registration is timeboxed and will expire by default in ten minutes, so for persistent offerings you should call the activate method in a timer loop and update the expiration time regularly.
 
 ### Validating subscriber JSON Web Tokens
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -29,6 +29,22 @@ const deleteOfferingMutation = gql`
     }
 `;
 
+const activateOfferingMutation = gql`
+    mutation activateOffering($Offering:ActivateOffering!){
+      activateOffering(input: $Offering){
+        id name
+        provider { id name organization { id name } }
+        activation { status expirationTime }
+        rdfAnnotation { uri label proposed }
+        inputs { name rdfAnnotation { uri label proposed } }
+        outputs { name rdfAnnotation { uri label proposed } }
+        spatialExtent { city boundary { l1 { lat lng } l2 { lat lng } } }
+        license
+        price { pricingModel money { amount currency } }
+      }
+    }
+`;
+
 class BigIotProvider extends Client {
   constructor(id, secret, market = 'https://market.big-iot.org') {
     super(market);
@@ -77,6 +93,29 @@ class BigIotProvider extends Client {
         Offering: offeringData,
       },
     }).then(result => result.data.deleteOffering.id);
+  }
+
+  activate(offering, expirationTime = null) {
+    if (!this.client) {
+      return Promise.reject(new Error('The provider must be authenticated before registering an offering'));
+    }
+    const offeringData = offering.toJSON();
+    if (offeringData.id == null) {
+      return Promise.reject(new Error('The offering must be registered before activating it'));
+    }
+    let expires = expirationTime;
+    if (!expires) {
+      // Default expiration in 10 minutes
+      expires = new Date();
+      expires.setMinutes(expires.getMinutes() + 10);
+    }
+    offeringData.expirationTime = expires;
+    return this.client.mutate({
+      mutation: activateOfferingMutation,
+      variables: {
+        Offering: offeringData,
+      },
+    }).then(result => result.data.activateOffering);
   }
 
   validateToken(token) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -45,6 +45,22 @@ const activateOfferingMutation = gql`
     }
 `;
 
+const deactivateOfferingMutation = gql`
+    mutation deactivateOffering($Offering:DeactivateOffering!){
+      deactivateOffering(input: $Offering){
+        id name
+        provider { id name organization { id name } }
+        activation { status expirationTime }
+        rdfAnnotation { uri label proposed }
+        inputs { name rdfAnnotation { uri label proposed } }
+        outputs { name rdfAnnotation { uri label proposed } }
+        spatialExtent { city boundary { l1 { lat lng } l2 { lat lng } } }
+        license
+        price { pricingModel money { amount currency } }
+      }
+    }
+`;
+
 class BigIotProvider extends Client {
   constructor(id, secret, market = 'https://market.big-iot.org') {
     super(market);
@@ -115,9 +131,29 @@ class BigIotProvider extends Client {
     return this.client.mutate({
       mutation: activateOfferingMutation,
       variables: {
-        Offering: offeringData,
+        Offering: {
+          id: offeringData.id,
+        },
       },
     }).then(result => result.data.activateOffering);
+  }
+
+  deactivate(offering) {
+    if (!this.client) {
+      return Promise.reject(new Error('The provider must be authenticated before registering an offering'));
+    }
+    const offeringData = offering.toJSON();
+    if (offeringData.id == null) {
+      return Promise.reject(new Error('The offering must be registered before activating it'));
+    }
+    return this.client.mutate({
+      mutation: deactivateOfferingMutation,
+      variables: {
+        Offering: {
+          id: offeringData.id,
+        },
+      },
+    }).then(result => result.data.deactivateOffering);
   }
 
   validateToken(token) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -144,7 +144,7 @@ class BigIotProvider extends Client {
     }
     const offeringData = offering.toJSON();
     if (offeringData.id == null) {
-      return Promise.reject(new Error('The offering must be registered before activating it'));
+      return Promise.reject(new Error('The offering must be registered before deactivating it'));
     }
     return this.client.mutate({
       mutation: deactivateOfferingMutation,

--- a/spec/provider.js
+++ b/spec/provider.js
@@ -106,6 +106,22 @@ describe('BIG IoT Provider', () => {
         expect(foundOffering.rdfAnnotation.uri).to.equal(off.rdfUri);
         expect(foundOffering.spatialExtent.city).to.equal(off.extent.city);
       });
+    it('should be able to deactivate offering', () => {
+      expect(off.id).to.be.a('string', 'Offering ID needs to be available');
+      prov.deactivate(off)
+        .then((result) => {
+          expect(result.activation.status).to.be.false;
+        });
+    });
+    it('should be able to activate offering and set new expiration time', () => {
+      expect(off.id).to.be.a('string', 'Offering ID needs to be available');
+      const expirationDate = new Date();
+      expirationDate.setMinutes(expirationDate.getMinutes() + 2);
+      prov.activate(off, expirationDate)
+        .then((result) => {
+          expect(result.activation.status).to.be.true;
+          expect(result.activation.expirationTime).to.equal(expirationDate.valueOf());
+        });
     });
     // Skipped until https://gitlab.com/BIG-IoT/exchange/issues/201 is resolved
     it.skip('should be able to delete an offering', () => {


### PR DESCRIPTION
It is now possible to activate and deactivate offering on the marketplace, so you don't have to re-register the offering every few minutes to keep it active or delete it to make it unaccessible. You can also set a new expiration time with the activate method.

This PR also includes tests for the two added methods and a small change to the README to reflect on those changes.