### PR TITLE
Fixed activate query to include expiration time, fixed tests

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -133,6 +133,7 @@ class BigIotProvider extends Client {
       variables: {
         Offering: {
           id: offeringData.id,
+          expirationTime: expires.valueOf(),
         },
       },
     }).then(result => result.data.activateOffering);

--- a/spec/provider.js
+++ b/spec/provider.js
@@ -109,7 +109,7 @@ describe('BIG IoT Provider', () => {
     });
     it('should be able to deactivate offering', () => {
       expect(off.id).to.be.a('string', 'Offering ID needs to be available');
-      prov.deactivate(off)
+      return prov.deactivate(off)
         .then((result) => {
           expect(result.activation.status).to.be.false;
         });
@@ -118,7 +118,7 @@ describe('BIG IoT Provider', () => {
       expect(off.id).to.be.a('string', 'Offering ID needs to be available');
       const expirationDate = new Date();
       expirationDate.setMinutes(expirationDate.getMinutes() + 2);
-      prov.activate(off, expirationDate)
+      return prov.activate(off, expirationDate)
         .then((result) => {
           expect(result.activation.status).to.be.true;
           expect(result.activation.expirationTime).to.equal(expirationDate.valueOf());


### PR DESCRIPTION
I noticed that I didnt actually Include the expirationTime variable in the gql-query. Oops.
Also that mistake didn't show because I forgot to return the promise inside the test. Double oops.
Should work as expected now.