### PR TITLE
Add query to get the Offering Description without subscribing to it

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -6,23 +6,23 @@ require('isomorphic-fetch');
 const Client = require('./client');
 
 const subscribeConsumerToOffering = gql`
-  mutation subscribeConsumerToOffering($subscription:SubscribeConsumerToOffering!) {
-    subscribeConsumerToOffering(input: $subscription) {
-      id accessToken
-      offering {
-        id
-        provider { id name organization { id name } }
-        activation { status expirationTime }
-        rdfAnnotation { uri label proposed }
-        inputs { name rdfAnnotation { uri } }
-        outputs { name rdfAnnotation { uri } }
-        endpoints { uri endpointType accessInterfaceType }
-        spatialExtent { city boundary { l1 { lat lng } l2 { lat lng } } }
-        license
-        price { pricingModel money { amount currency } }
+    mutation subscribeConsumerToOffering($subscription:SubscribeConsumerToOffering!) {
+      subscribeConsumerToOffering(input: $subscription) {
+        id accessToken
+        offering {
+          id
+          provider { id name organization { id name } }
+          activation { status expirationTime }
+          rdfAnnotation { uri label proposed }
+          inputs { name rdfAnnotation { uri } }
+          outputs { name rdfAnnotation { uri } }
+          endpoints { uri endpointType accessInterfaceType }
+          spatialExtent { city boundary { l1 { lat lng } l2 { lat lng } } }
+          license
+          price { pricingModel money { amount currency } }
+        }
       }
     }
-  }
 `;
 
 const addOfferingQuery = gql`
@@ -50,6 +50,26 @@ const matchOfferings = gql`
     }
 `;
 
+const getOffering = gql`
+    query offering($offeringId: String!) {
+      offering(id: $offeringId) {
+        id
+        name
+        accessWhiteList
+        provider { id name organization { id name } }
+        rdfAnnotation { uri label proposed }
+        rdfContext { context prefixes { prefix uri } }
+        endpoints { endpointType uri accessInterfaceType }
+        outputs { name rdfAnnotation { uri label proposed } }
+        inputs { name rdfAnnotation { uri label proposed } }
+        spatialExtent { city boundary { l1 { lat lng } l2 { lat lng } } }
+        temporalExtent { from to }
+        license
+        price { pricingModel money { amount currency } }
+        activation { status expirationTime }
+      }
+    }`;
+
 class BigIotConsumer extends Client {
   constructor(id, secret, market = 'https://market.big-iot.org', cors = undefined) {
     super(market, cors);
@@ -69,8 +89,7 @@ class BigIotConsumer extends Client {
           offeringId,
         },
       },
-    })
-      .then(result => result.data.subscribeConsumerToOffering);
+    }).then(result => result.data.subscribeConsumerToOffering);
   }
 
   access(subscription, inputs) {
@@ -80,13 +99,12 @@ class BigIotConsumer extends Client {
       headers: {
         Authorization: `Bearer ${subscription.accessToken}`,
       },
-    })
-      .then((response) => {
-        if (response.status !== 200) {
-          throw new Error(`Provider failed with ${response.status}: ${response.statusText}`);
-        }
-        return response.json();
-      });
+    }).then((response) => {
+      if (response.status !== 200) {
+        throw new Error(`Provider failed with ${response.status}: ${response.statusText}`);
+      }
+      return response.json();
+    });
   }
 
   discover(offering) {
@@ -99,14 +117,21 @@ class BigIotConsumer extends Client {
       variables: {
         newOfferingQuery: query,
       },
-    })
-      .then(result => this.client.query({
-        query: matchOfferings,
-        variables: {
-          queryId: result.data.addOfferingQuery.id,
-        },
-      }))
-      .then(result => result.data.matchingOfferings);
+    }).then(result => this.client.query({
+      query: matchOfferings,
+      variables: {
+        queryId: result.data.addOfferingQuery.id,
+      },
+    })).then(result => result.data.matchingOfferings);
+  }
+
+  get(id) {
+    return this.client.query({
+      query: getOffering,
+      variables: {
+        offeringId: id,
+      },
+    }).then(result => result.data.offering);
   }
 }
 


### PR DESCRIPTION
Add a GraphQL query in the consumer lib to fetch an OD from the marketplace without creating a subscription.
(Used in [my thesis project](https://github.com/nsorin/wot-big-iot) to perform a semantic conversion from the BIG IoT model to the Web of Things model. Others may have use for this.)